### PR TITLE
Return track list details

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -339,7 +339,7 @@ async def get_analysis_breakdown(analysis_id: str):
 async def get_analysis_details_endpoint(analysis_id: str):
     try:
         details = get_analysis_details(analysis_id)
-        return ApiResponseFormatter.success(details)
+        return ApiResponseFormatter.success({"tracks": details})
     except Exception as e:
         return ApiResponseFormatter.error(e)
 

--- a/Frontend/spotify-analyzer/src/pages/ResultPage.jsx
+++ b/Frontend/spotify-analyzer/src/pages/ResultPage.jsx
@@ -40,11 +40,13 @@ function ResultPage() {
   useEffect(() => {
     const fetchDetails = async () => {
       try {
-        const res = await fetch(`${import.meta.env.VITE_API_URL}/analysis/${analysisId}/details`);
+        const res = await fetch(
+          `${import.meta.env.VITE_API_URL}/analysis/${analysisId}/details`
+        );
         const { data, status } = await res.json();
-        if (status === "success") {
+        if (status === "success" && Array.isArray(data.tracks)) {
           const mapping = {};
-          for (const track of data.tracks || []) {
+          for (const track of data.tracks) {
             for (const genre of track.genres || []) {
               if (!mapping[genre]) mapping[genre] = [];
               mapping[genre].push(track.id);


### PR DESCRIPTION
## Summary
- adjust analysis details retrieval to return per-track genre info
- update details endpoint to wrap tracks list in API response
- refine result page data parsing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pymongo and spotipy)*

------
https://chatgpt.com/codex/tasks/task_e_684f7731cce88321935dd573613dbe8b