### PR TITLE
Fix async rate limiter and playlist workflow

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -252,11 +252,13 @@ async def full_auto_playlist_creation(analysis_id: str = Body(..., embed=True)):
                 detail="Analiz bulunamadı"
             )
 
-        # 2. Tüm şarkıları al
-        track_ids = [track["id"] for track in analysis.get("tracks", [])]
-
-        # 3. Tür analizi yap
-        genre_map = analyze_genres(track_ids)
+        # 2. Tür verisi hazır mı kontrol et
+        if analysis.get("genres"):
+            genre_map = analysis["genres"]
+        else:
+            # Önceden analiz edilmemişse şarkıları alıp analiz et
+            track_ids = [track["id"] for track in analysis.get("tracks", [])]
+            genre_map = analyze_genres(track_ids)
 
         # 4. Playlist oluştur
         creator = PlaylistCreator()

--- a/Backend/genre_finder.py
+++ b/Backend/genre_finder.py
@@ -106,7 +106,10 @@ class GenreFinder:
                 timeout=REQUEST_TIMEOUT
             )
             response.raise_for_status()
-            return [tag['name'].lower() for tag in response.json().get('recordings', [{}])[0].get('tags', [])][:3]
+            data = response.json().get('recordings', [])
+            if not data:
+                return []
+            return [tag['name'].lower() for tag in data[0].get('tags', [])][:3]
         except Exception as e:
             logger.warning(f"MusicBrainz verisi alınamadı: {e}")
             return []


### PR DESCRIPTION
## Summary
- support async functions in `RateLimiter`
- guard against empty results in `GenreFinder`
- reuse existing analysis data when auto-generating playlists

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_6847386bf7548321a3f633e2641ac1a0