### PR TITLE
Remove unused requirements

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,11 +1,8 @@
-pip
-flask~=3.1.1
 spotipy~=2.25.1
 requests~=2.32.3
 pandas
 python-dotenv~=1.1.0
 pymongo~=4.13.0
-flask-cors~=6.0.0
 tenacity~=9.1.2
 uvicorn~=0.34.2
 fastapi~=0.115.12


### PR DESCRIPTION
## Summary
- delete unused Flask packages and pip entry from `Backend/requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684f70b585608321bb8a76ca3b2c2502