### PR TITLE
Add backend env example and mention in README

### DIFF
--- a/Backend/.env.example
+++ b/Backend/.env.example
@@ -1,0 +1,26 @@
+# Spotify API credentials
+SPOTIPY_CLIENT_ID=your_spotify_client_id
+SPOTIPY_CLIENT_SECRET=your_spotify_client_secret
+SPOTIPY_REDIRECT_URI=http://localhost:8080/callback
+
+# MongoDB connection
+MONGO_URI=mongodb://localhost:27017
+MONGO_DB=spotify_analytics
+
+# Optional configuration
+LASTFM_API_KEY=your_lastfm_key
+GENRE_FINDER_MAX_WORKERS=5
+GENRE_FINDER_TIMEOUT=15
+GENRE_CACHE_TTL=30
+FRONTEND_REDIRECT_URI=http://127.0.0.1:5173?login=success
+ENVIRONMENT=development
+HOST=0.0.0.0
+PORT=8080
+DEBUG_MODE=false
+MAX_TRACKS=5000
+WORKFLOW_MAX_WORKERS=5
+PLAYLIST_MAX_RETRIES=5
+PLAYLIST_REQUEST_DELAY=1.2
+PLAYLIST_PREFIX=Analiz - 
+PLAYLIST_CACHE_TTL=30
+

--- a/Frontend/spotify-analyzer/README.md
+++ b/Frontend/spotify-analyzer/README.md
@@ -10,3 +10,7 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment Configuration
+
+Copy `Backend/.env.example` to `Backend/.env` and fill in the required credentials before running the backend.


### PR DESCRIPTION
## Summary
- document backend environment variables in `Backend/.env.example`
- explain how to use the example file in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `pymongo`, `spotipy`)*

------
https://chatgpt.com/codex/tasks/task_e_684f70f2d6d48321ba67de8007e5bcce