### PR TITLE
Fix frontend base URL handling

### DIFF
--- a/Frontend/spotify-analyzer/src/App.jsx
+++ b/Frontend/spotify-analyzer/src/App.jsx
@@ -7,6 +7,8 @@ import './index.css';
 import { UserContext } from './UserContext.jsx';
 import { logout as apiLogout } from './api.js';
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || '';
+
 const slogans = [
   "Türlerin ötesine geç!",
   "Müziğini analiz et.",
@@ -45,7 +47,7 @@ function App() {
       // Analiz seçenek sayfasına git (bir sonraki adımda yapılacak)
       window.location.href = "/analyze/liked";
     } else {
-      window.location.href = `${import.meta.env.VITE_API_URL}/login`;
+      window.location.href = `${API_BASE_URL}/login`;
     }
   };
 

--- a/Frontend/spotify-analyzer/src/api.js
+++ b/Frontend/spotify-analyzer/src/api.js
@@ -1,6 +1,8 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || window.location.origin;
+
 export const createPlaylists = async (analysisId, selectedTracks = {}, excludedTracks = []) => {
   try {
-    const response = await fetch("http://127.0.0.1:8080/playlists", {
+    const response = await fetch(`${API_BASE_URL}/playlists`, {
       method: "POST",
       mode: "cors",
       credentials: "include",
@@ -30,7 +32,7 @@ export const createPlaylists = async (analysisId, selectedTracks = {}, excludedT
 
 export const fetchUserAnalyses = async () => {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}/user/analyses`, {
+    const response = await fetch(`${API_BASE_URL}/user/analyses`, {
       method: "GET",
       mode: "cors",
       credentials: "include",
@@ -50,7 +52,7 @@ export const fetchUserAnalyses = async () => {
 
 export const fetchUserProfile = async () => {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}/user/profile`, {
+    const response = await fetch(`${API_BASE_URL}/user/profile`, {
       method: "GET",
       mode: "cors",
       credentials: "include",
@@ -79,7 +81,7 @@ export const fetchUserProfile = async () => {
 
 export const logout = async () => {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}/logout`, {
+    const response = await fetch(`${API_BASE_URL}/logout`, {
       method: "POST",
       mode: "cors",
       credentials: "include",

--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ npm install
 npm run dev
 ```
 This starts the Vite development server, typically reachable at `http://localhost:5173`.
+The frontend expects an API endpoint specified in `Frontend/spotify-analyzer/.env`:
+
+```
+VITE_API_URL=http://127.0.0.1:8080
+```
+
+If your backend is running on a different host or port (for example when using a
+remote container), update `VITE_API_URL` accordingly so that login redirects work
+correctly.


### PR DESCRIPTION
## Summary
- default to same-origin API base URL
- use API_BASE_URL constant across React frontend
- document `VITE_API_URL` usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684f914eb8948321a1278fb8eef25efd