### PR TITLE
Fix placeholder image domain

### DIFF
--- a/Frontend/spotify-analyzer/src/components/UserMenu.jsx
+++ b/Frontend/spotify-analyzer/src/components/UserMenu.jsx
@@ -9,7 +9,7 @@ function UserMenu() {
   const name = localStorage.getItem('userName') || 'Kullanıcı';
   const image =
     localStorage.getItem('userImage') ||
-    'https://via.placeholder.com/32';
+    '/vite.svg';
 
   useEffect(() => {
     const handleClick = (e) => {


### PR DESCRIPTION
## Summary
- avoid hitting `via.placeholder.com` for user menu avatar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo', 'spotipy')*

------
https://chatgpt.com/codex/tasks/task_e_684f966f35508321b2e436bff969e7b1