### PR TITLE
Fix login context and playlist analysis page

### DIFF
--- a/Frontend/spotify-analyzer/src/main.jsx
+++ b/Frontend/spotify-analyzer/src/main.jsx
@@ -6,25 +6,30 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Callback from './pages/Callback.jsx';
 import AnalyzeOptions from './pages/AnalyzeOptions.jsx';
 import AnalyzeLiked from './pages/AnalyzeLiked.jsx';
+import AnalyzePlaylist from './pages/AnalyzePlaylist.jsx';
 import ResultPage from './pages/ResultPage.jsx';
 import AnalyzePage from './pages/AnalyzePage.jsx';
 import History from './pages/History.jsx';
 import Layout from './components/Layout.jsx';
+import { UserProvider } from './UserContext.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<Layout />}>
-          <Route path="/" element={<App />} />
-          <Route path="/callback" element={<Callback />} />
+    <UserProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<App />} />
+            <Route path="/callback" element={<Callback />} />
           <Route path="/analyze" element={<AnalyzeOptions />} />
+          <Route path="/analyze/playlist" element={<AnalyzePlaylist />} />
           <Route path="/analyze/liked" element={<AnalyzeLiked />} />
-          <Route path="/result/:analysisId" element={<ResultPage />} />
-          <Route path="/analyze/result/:analysisId" element={<AnalyzePage />} />
-          <Route path="/history" element={<History />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+            <Route path="/result/:analysisId" element={<ResultPage />} />
+            <Route path="/analyze/result/:analysisId" element={<AnalyzePage />} />
+            <Route path="/history" element={<History />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </UserProvider>
   </React.StrictMode>,
 );

--- a/Frontend/spotify-analyzer/src/pages/AnalyzePlaylist.jsx
+++ b/Frontend/spotify-analyzer/src/pages/AnalyzePlaylist.jsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import UserMenu from "../components/UserMenu.jsx";
+import PageWrapper from "../components/PageWrapper.jsx";
+
+function AnalyzePlaylist() {
+  const [playlistUrl, setPlaylistUrl] = useState("");
+  const [status, setStatus] = useState("");
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const extractId = (url) => {
+    const match = url.match(/playlist\/(.+?)(\?|$)/);
+    return match ? match[1] : url;
+  };
+
+  const handleAnalyze = async () => {
+    const playlistId = extractId(playlistUrl.trim());
+    if (!playlistId) return;
+    setLoading(true);
+    setStatus("Analiz başlatılıyor...");
+    try {
+      const res = await fetch(`${import.meta.env.VITE_API_URL}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ playlist_id: playlistId }),
+      });
+      const data = await res.json();
+      if (res.ok && data.status === "success") {
+        setStatus("Analiz tamamlandı, yönlendiriliyor...");
+        setTimeout(() => navigate(`/result/${data.data.analysis_id}`), 1000);
+      } else {
+        throw new Error(data.message || "Analiz başarısız");
+      }
+    } catch (e) {
+      setStatus(`Hata: ${e.message}`);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <PageWrapper>
+      <div className="flex flex-col items-center justify-center h-screen bg-black text-white gap-4 relative">
+        <UserMenu />
+        <h1 className="text-2xl font-bold mb-4">Çalma Listesi Analizi</h1>
+        <input
+          type="text"
+          value={playlistUrl}
+          onChange={(e) => setPlaylistUrl(e.target.value)}
+          placeholder="Playlist URL veya ID"
+          className="w-80 px-3 py-2 rounded text-black"
+        />
+        <button
+          onClick={handleAnalyze}
+          disabled={loading || !playlistUrl.trim()}
+          className="bg-green-500 hover:bg-green-600 text-black font-semibold py-2 px-6 rounded-full disabled:bg-gray-600"
+        >
+          Analiz Et
+        </button>
+        {status && <p className="mt-4 text-center">{status}</p>}
+      </div>
+    </PageWrapper>
+  );
+}
+
+export default AnalyzePlaylist;
+

--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ VITE_API_URL=http://127.0.0.1:8080
 If your backend is running on a different host or port (for example when using a
 remote container), update `VITE_API_URL` accordingly so that login redirects work
 correctly.
+
+### Available Pages
+
+- `/` – login or start page
+- `/analyze` – choose between liked tracks or playlist analysis
+- `/analyze/liked` – automatically analyze your liked songs
+- `/analyze/playlist` – analyze any playlist by URL or ID


### PR DESCRIPTION
## Summary
- wrap app with `UserProvider`
- add a new `AnalyzePlaylist` page to analyze arbitrary playlists
- route to new page from router
- document available pages in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pymongo')*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f98561c98832196e2cb5b6b77c509