### PR TITLE
Improve cached playlist handling and result UI

### DIFF
--- a/Backend/playlist_creator.py
+++ b/Backend/playlist_creator.py
@@ -69,7 +69,11 @@ class PlaylistCreator:
 
             if cached:
                 logger.info(f"🎧 Playlist önbellekten alındı: {name}")
-                return cached
+                return {
+                    "id": cached.get("_id"),
+                    "snapshot_id": cached.get("snapshot_id"),
+                    "external_urls": {"spotify": cached.get("url")}
+                }
 
             playlist = smart_request_with_retry(
                 self.sp.user_playlist_create,

--- a/Frontend/spotify-analyzer/src/components/SelectionPanel.jsx
+++ b/Frontend/spotify-analyzer/src/components/SelectionPanel.jsx
@@ -1,10 +1,25 @@
+import { useState } from "react";
+
 function SelectionPanel({
   genres,
   selectedGenres,
   excludedTrackIds,
-  toggleExclude
+  toggleExclude,
+  manualAssignments,
+  setManualAssignments,
 }) {
   const visibleGenres = [...selectedGenres].filter((genre) => genres[genre]);
+  const [openGenres, setOpenGenres] = useState([]);
+
+  const toggleOpen = (genre) => {
+    setOpenGenres((prev) =>
+      prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre]
+    );
+  };
+
+  const handleAssign = (id, genre) => {
+    setManualAssignments((prev) => ({ ...prev, [id]: genre }));
+  };
 
   if (visibleGenres.length === 0) {
     return (
@@ -15,44 +30,67 @@ function SelectionPanel({
   }
 
   return (
-    <div className="w-full max-w-4xl mt-8 space-y-8">
+    <div className="w-full max-w-4xl mt-8 space-y-4">
       {visibleGenres.map((genre) => (
-        <div key={genre}>
-          <h3 className="text-lg font-bold text-green-400 mb-2">{genre}</h3>
-          <div className="grid gap-2 md:grid-cols-2">
-            {genres[genre].map((track) => (
-              <div
-                key={track.id}
-                className={`flex justify-between items-center p-3 rounded-lg border ${
-                  excludedTrackIds.includes(track.id)
-                    ? "bg-gray-800 border-red-500 text-red-400 line-through"
-                    : "bg-gray-900 border-gray-700"
-                }`}
-              >
-                <div className="flex-1">
-                  <div className="font-medium">{track.name}</div>
-                  <div className="text-sm text-gray-400">{track.artist}</div>
-                </div>
-                {track.preview_url && (
-                  <audio
-                    controls
-                    src={track.preview_url}
-                    className="w-32 mr-2"
-                  />
-                )}
-                <button
-                  onClick={() => toggleExclude(track.id)}
-                  className={`text-sm font-bold px-3 py-1 rounded-full ${
+        <div key={genre} className="bg-gray-900 rounded-lg overflow-hidden">
+          <button
+            onClick={() => toggleOpen(genre)}
+            className="w-full text-left px-4 py-2 bg-gray-800 hover:bg-gray-700 font-bold"
+          >
+            {genre}
+          </button>
+          {openGenres.includes(genre) && (
+            <div className="p-3 space-y-2 max-h-60 overflow-y-auto">
+              {genres[genre].map((track) => (
+                <div
+                  key={track.id}
+                  className={`flex justify-between items-center p-2 rounded border ${
                     excludedTrackIds.includes(track.id)
-                      ? "bg-red-500 text-white"
-                      : "bg-gray-600 text-white"
+                      ? "bg-gray-800 border-red-500 text-red-400 line-through"
+                      : "bg-gray-900 border-gray-700"
                   }`}
                 >
-                  {excludedTrackIds.includes(track.id) ? "Geri Al" : "Hariç Tut"}
-                </button>
-              </div>
-            ))}
-          </div>
+                  <div className="flex-1 mr-2">
+                    <div className="font-medium">{track.name}</div>
+                    <div className="text-sm text-gray-400">{track.artist}</div>
+                  </div>
+                  {genre === "unknown" && (
+                    <select
+                      value={manualAssignments[track.id] || ""}
+                      onChange={(e) => handleAssign(track.id, e.target.value)}
+                      className="bg-gray-700 text-white text-sm rounded mr-2"
+                    >
+                      <option value="">Tür Seç</option>
+                      {Object.keys(genres)
+                        .filter((g) => g !== "unknown")
+                        .map((opt) => (
+                          <option key={opt} value={opt}>
+                            {opt}
+                          </option>
+                        ))}
+                    </select>
+                  )}
+                  {track.preview_url && (
+                    <audio
+                      controls
+                      src={track.preview_url}
+                      className="w-32 mr-2"
+                    />
+                  )}
+                  <button
+                    onClick={() => toggleExclude(track.id)}
+                    className={`text-sm font-bold px-3 py-1 rounded-full ${
+                      excludedTrackIds.includes(track.id)
+                        ? "bg-red-500 text-white"
+                        : "bg-gray-600 text-white"
+                    }`}
+                  >
+                    {excludedTrackIds.includes(track.id) ? "Geri Al" : "Hariç Tut"}
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- fix cached playlist structure by returning `id`, `snapshot_id`, and URL
- add collapsible panels and genre assignment UI to `SelectionPanel`
- show analysis stats on the result page and support manual track assignments when creating playlists

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684fab7d3ef48321aba20b6f6f551ef0