### PR TITLE
Improve playlist saving and UI

### DIFF
--- a/Backend/playlist_creator.py
+++ b/Backend/playlist_creator.py
@@ -89,6 +89,15 @@ class PlaylistCreator:
             }
 
             self.collection.insert_one(playlist_doc)
+
+            try:
+                # Follow the playlist so it appears in the user's library
+                smart_request_with_retry(
+                    self.sp.current_user_follow_playlist, playlist["id"]
+                )
+            except Exception as e:
+                logger.warning(f"Playlist takip edilemedi: {e}")
+
             return playlist
 
         except Exception as e:

--- a/Frontend/spotify-analyzer/src/components/UserMenu.jsx
+++ b/Frontend/spotify-analyzer/src/components/UserMenu.jsx
@@ -1,14 +1,20 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { logout as apiLogout } from "../api.js";
+import { UserContext } from "../UserContext.jsx";
 
 function UserMenu() {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
   const navigate = useNavigate();
+  const { isLoggedIn, setIsLoggedIn, profile, setProfile } = useContext(UserContext);
 
-  const name = localStorage.getItem("userName") || "Kullanıcı";
-  const image = localStorage.getItem("userImage") || "/vite.svg";
+  const name =
+    profile?.display_name || localStorage.getItem("userName") || "Kullanıcı";
+  const image =
+    (profile?.images && profile.images[0]?.url) ||
+    localStorage.getItem("userImage") ||
+    "/vite.svg";
 
   useEffect(() => {
     const handleClick = (e) => {
@@ -27,9 +33,24 @@ function UserMenu() {
       console.error("Logout failed", e);
     } finally {
       localStorage.removeItem("isLoggedIn");
+      setIsLoggedIn(false);
+      setProfile(null);
       navigate("/");
     }
   };
+
+  if (!isLoggedIn) {
+    return (
+      <button
+        onClick={() => {
+          window.location.href = `${import.meta.env.VITE_API_URL}/login`;
+        }}
+        className="px-4 py-2 bg-green-500 text-black rounded-full"
+      >
+        Giriş Yap
+      </button>
+    );
+  }
 
   return (
     <div className="relative" ref={ref}>

--- a/Frontend/spotify-analyzer/src/pages/ResultPage.jsx
+++ b/Frontend/spotify-analyzer/src/pages/ResultPage.jsx
@@ -27,6 +27,7 @@ function ResultPage() {
           const genreList = Object.entries(data).map(([genre, value]) => ({
             genre,
             percentage: value.percentage,
+            count: value.count,
           }));
           setGenres(genreList);
         } else {
@@ -66,6 +67,9 @@ function ResultPage() {
       prev.includes(genre) ? prev.filter((g) => g !== genre) : [...prev, genre],
     );
   };
+
+  const getCountForGenre = (genre) =>
+    genres.find((g) => g.genre === genre)?.count || 0;
 
   const toggleExclude = (id) => {
     setExcludedTrackIds((prev) =>
@@ -213,6 +217,17 @@ function ResultPage() {
                   </span>
                 ))}
               </div>
+              {selectedGenres.length > 0 ? (
+                <ul className="mt-2 text-sm text-gray-300">
+                  {selectedGenres.map((g) => (
+                    <li key={g}>{g}: {getCountForGenre(g)} şarkı</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-gray-400">
+                  Grafikte bir türe tıklayarak şarkı sayısını görebilirsin.
+                </p>
+              )}
             </div>
 
             <SelectionPanel


### PR DESCRIPTION
## Summary
- ensure playlists are followed after creation so they show up in library
- show login button before login and user info after login
- display track counts when clicking genres in results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684fb486bb008321a15d32142439b956