### PR TITLE
Fix login state persistence

### DIFF
--- a/Frontend/spotify-analyzer/src/App.jsx
+++ b/Frontend/spotify-analyzer/src/App.jsx
@@ -1,5 +1,6 @@
 // App.jsx
 import { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import UserMenu from './components/UserMenu.jsx';
 import PageWrapper from './components/PageWrapper.jsx';
@@ -21,6 +22,7 @@ function App() {
   const [currentSlogan, setCurrentSlogan] = useState(0);
   const [feedback, setFeedback] = useState("");
   const { isLoggedIn, setIsLoggedIn, setProfile } = useContext(UserContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -52,8 +54,8 @@ function App() {
 
   const handleButtonClick = () => {
     if (isLoggedIn) {
-      // Analiz seçenek sayfasına git (bir sonraki adımda yapılacak)
-      window.location.href = "/analyze/liked";
+      // Navigate without full reload
+      navigate("/analyze/liked");
     } else {
       window.location.href = `${API_BASE_URL}/login`;
     }
@@ -66,6 +68,9 @@ function App() {
       console.error("Logout failed", e);
     } finally {
       localStorage.removeItem("isLoggedIn");
+      localStorage.removeItem("userName");
+      localStorage.removeItem("userImage");
+      localStorage.removeItem("profile");
       setIsLoggedIn(false);
       setProfile(null);
       window.location.href = "/";

--- a/Frontend/spotify-analyzer/src/UserContext.jsx
+++ b/Frontend/spotify-analyzer/src/UserContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
 
 export const UserContext = createContext({
   profile: null,
@@ -8,8 +8,29 @@ export const UserContext = createContext({
 });
 
 export function UserProvider({ children }) {
-  const [profile, setProfile] = useState(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [profile, setProfile] = useState(() => {
+    const stored = localStorage.getItem('profile');
+    try {
+      return stored ? JSON.parse(stored) : null;
+    } catch {
+      return null;
+    }
+  });
+  const [isLoggedIn, setIsLoggedIn] = useState(
+    localStorage.getItem('isLoggedIn') === 'true'
+  );
+
+  useEffect(() => {
+    localStorage.setItem('isLoggedIn', isLoggedIn ? 'true' : 'false');
+  }, [isLoggedIn]);
+
+  useEffect(() => {
+    if (profile) {
+      localStorage.setItem('profile', JSON.stringify(profile));
+    } else {
+      localStorage.removeItem('profile');
+    }
+  }, [profile]);
 
   return (
     <UserContext.Provider value={{ profile, setProfile, isLoggedIn, setIsLoggedIn }}>

--- a/Frontend/spotify-analyzer/src/api.js
+++ b/Frontend/spotify-analyzer/src/api.js
@@ -71,6 +71,8 @@ export const fetchUserProfile = async () => {
     if (profile.images && profile.images[0]?.url) {
       localStorage.setItem("userImage", profile.images[0].url);
     }
+    // Store full profile for persistence
+    localStorage.setItem("profile", JSON.stringify(profile));
 
     return profile;
   } catch (err) {


### PR DESCRIPTION
## Summary
- persist login state in `UserProvider`
- store entire user profile in `fetchUserProfile`
- remove all stored user info on logout
- navigate to analysis page without full reload

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684fb8a598408321a683694abdaf5066