### PR TITLE
Add playlist URL to cache and improve logging

### DIFF
--- a/Backend/playlist_creator.py
+++ b/Backend/playlist_creator.py
@@ -84,6 +84,7 @@ class PlaylistCreator:
                 "name": name,
                 "owner": self.user_id,
                 "tracks": [],
+                "url": playlist.get("external_urls", {}).get("spotify"),
                 "created_at": datetime.utcnow(),
                 "expires_at": datetime.utcnow() + timedelta(days=CACHE_TTL_DAYS)
             }
@@ -154,11 +155,16 @@ class PlaylistCreator:
                     # Şarkı ekleme
                     success, count = await asyncio.to_thread(self._add_tracks_safe, playlist["id"], filtered_ids)
 
+                    if count == 0:
+                        logger.warning(f"{genre} türü için şarkılar eklenemedi, playlist boş olabilir.")
+                    else:
+                        logger.info(f"{genre} türü playlistine {count} şarkı eklendi")
+
                     results[genre] = {
                         "playlist_id": playlist["id"],
                         "track_count": count,
                         "snapshot_id": playlist.get("snapshot_id", "unknown"),
-                        "url": playlist.get("external_urls", {}).get("spotify", "#")
+                        "url": playlist.get("external_urls", {}).get("spotify") or playlist.get("url", "#")
                     }
 
                     # MongoDB kayıt


### PR DESCRIPTION
## Summary
- store playlist URL in MongoDB cache when creating playlists
- log a warning if no tracks are added to a playlist
- include cached URL when returning playlist info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pymongo and spotipy)*

------
https://chatgpt.com/codex/tasks/task_e_684fbb6f7f98832188f8d76d417ca555