### PR TITLE
Fix login redirect and show error

### DIFF
--- a/Frontend/spotify-analyzer/src/App.jsx
+++ b/Frontend/spotify-analyzer/src/App.jsx
@@ -1,5 +1,6 @@
 // App.jsx
 import { useEffect, useState, useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import UserMenu from './components/UserMenu.jsx';
 import PageWrapper from './components/PageWrapper.jsx';
@@ -21,6 +22,7 @@ function App() {
   const [currentSlogan, setCurrentSlogan] = useState(0);
   const [feedback, setFeedback] = useState("");
   const { isLoggedIn, setIsLoggedIn, setProfile } = useContext(UserContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const url = new URL(window.location.href);
@@ -52,8 +54,8 @@ function App() {
 
   const handleButtonClick = () => {
     if (isLoggedIn) {
-      // Analiz seçenek sayfasına git (bir sonraki adımda yapılacak)
-      window.location.href = "/analyze/liked";
+      // Analiz seçenek sayfasına git
+      navigate("/analyze");
     } else {
       window.location.href = `${API_BASE_URL}/login`;
     }

--- a/Frontend/spotify-analyzer/src/pages/Callback.jsx
+++ b/Frontend/spotify-analyzer/src/pages/Callback.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useContext } from 'react';
+import { useEffect, useContext, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchUserProfile } from '../api.js';
 import { UserContext } from '../UserContext.jsx';
@@ -7,6 +7,7 @@ import PageWrapper from '../components/PageWrapper.jsx';
 function CallbackPage() {
   const navigate = useNavigate();
   const { setIsLoggedIn, setProfile } = useContext(UserContext);
+  const [error, setError] = useState("");
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -21,19 +22,19 @@ function CallbackPage() {
         .catch((e) => console.error("Profile fetch error", e))
         .finally(() => {
           setTimeout(() => {
-            navigate('/');
+            navigate('/analyze');
           }, 1000);
         });
     } else {
-      // Hatalı yönlendirme olursa hata sayfasına gönder
-      navigate('/error'); // varsa
+      const errorMsg = params.get('error') || 'Giriş başarısız';
+      setError(errorMsg);
     }
   }, [navigate, setIsLoggedIn, setProfile]);
 
   return (
     <PageWrapper>
       <div className="flex items-center justify-center h-screen bg-[#191414] text-white text-xl">
-        Spotify hesabınız bağlandı, yönlendiriliyorsunuz...
+        {error ? `Hata: ${error}` : 'Spotify hesabınız bağlandı, yönlendiriliyorsunuz...'}
       </div>
     </PageWrapper>
   );


### PR DESCRIPTION
## Summary
- send users to the analyze page right after a successful login
- show any login errors on the callback page
- make the homepage navigate using react-router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684fc1d52ff08321b16ed63d357b7662