### PR TITLE
Fix login callback redirect

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -117,7 +117,12 @@ def auth_callback(code: str):
         token_info = auth_manager._add_metadata(token_info)
         auth_manager._save_token(token_info)
 
-        return RedirectResponse(url=os.getenv("FRONTEND_REDIRECT_URI", "http://127.0.0.1:5173?login=success"))
+        return RedirectResponse(
+            url=os.getenv(
+                "FRONTEND_REDIRECT_URI",
+                "http://127.0.0.1:5173/callback?login=success",
+            )
+        )
     except Exception as e:
         logger.error(f"Auth callback hatası: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail="Authentication failed")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Create a `.env` file in the `Backend` directory (or set the variables in your en
 Optional variables used by the backend:
 
 - `MONGO_DB` – Mongo database name (default `spotify_analytics`)
-- `FRONTEND_REDIRECT_URI` – URL to redirect after login (default `http://127.0.0.1:5173?login=success`)
+- `FRONTEND_REDIRECT_URI` – URL to redirect after login (default `http://127.0.0.1:5173/callback?login=success`)
 - `HOST` – binding host for the API server (default `0.0.0.0`)
 - `PORT` – binding port for the API server (default `8080`)
 - `DEBUG_MODE` – set to `true` for auto reload


### PR DESCRIPTION
## Summary
- redirect login callback to `/callback` page
- update README with new default redirect URL

## Testing
- `pytest -q` *(fails: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684fc75d712883219e68e2bf5d1d5de3