### PR TITLE
Fix playlist creator cached playlists

### DIFF
--- a/Backend/playlist_creator.py
+++ b/Backend/playlist_creator.py
@@ -72,6 +72,13 @@ class PlaylistCreator:
                     # Verify that the playlist still exists on Spotify
                     smart_request_with_retry(self.sp.playlist, cached["_id"])
                     logger.info(f"🎧 Playlist önbellekten alındı: {name}")
+                    cached.setdefault("id", cached.get("_id"))
+                    try:
+                        smart_request_with_retry(
+                            self.sp.current_user_follow_playlist, cached["_id"]
+                        )
+                    except Exception as e:
+                        logger.warning(f"Playlist takip işlemi başarısız: {e}")
                     return cached
                 except Exception:
                     logger.warning(
@@ -98,6 +105,7 @@ class PlaylistCreator:
 
             playlist_doc = {
                 "_id": playlist.get("id", ""),
+                "id": playlist.get("id", ""),
                 "name": name,
                 "owner": self.user_id,
                 "tracks": [],


### PR DESCRIPTION
## Summary
- ensure playlist ID exists when returning cached playlist
- store `id` field with playlist document
- refollow cached playlists so they appear in the library

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pymongo')*
- `pip install -q -r Backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684fcb50b2008321b73228f6884098f6