### PR TITLE
Fix login flow with consistent endpoints

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -357,6 +357,8 @@ async def logout_user(response: Response, request: Request):
     try:
         user_id = request.cookies.get("spotify_user_id")
         auth_manager.clear_tokens(user_id)
+        # clear current user so a new user can log in
+        auth_manager.set_current_user(None)
         response.delete_cookie("spotify_user_id")
         return ApiResponseFormatter.success({"message": "Logout successful"})
     except Exception as e:

--- a/Frontend/spotify-analyzer/src/components/Layout.jsx
+++ b/Frontend/spotify-analyzer/src/components/Layout.jsx
@@ -2,7 +2,7 @@ import { Outlet, Link } from 'react-router-dom';
 import { useContext } from 'react';
 import UserMenu from './UserMenu.jsx';
 import { UserContext } from '../UserContext.jsx';
-import { API_BASE_URL } from '../config.js';
+import { fetchAuthUrl } from '../api.js';
 
 function Layout() {
   const { isLoggedIn } = useContext(UserContext);
@@ -13,12 +13,15 @@ function Layout() {
         {isLoggedIn ? (
           <UserMenu />
         ) : (
-          <a
-            href={`${API_BASE_URL}/login`}
+          <button
+            onClick={async () => {
+              const url = await fetchAuthUrl();
+              window.location.href = url;
+            }}
             className="text-sm bg-green-500 hover:bg-green-600 text-black font-semibold py-1 px-3 rounded"
           >
             Giriş Yap
-          </a>
+          </button>
         )}
       </header>
       <main className="pt-16">

--- a/Frontend/spotify-analyzer/src/components/UserMenu.jsx
+++ b/Frontend/spotify-analyzer/src/components/UserMenu.jsx
@@ -1,8 +1,7 @@
 import { useState, useEffect, useRef, useContext } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { logout as apiLogout } from "../api.js";
+import { logout as apiLogout, fetchAuthUrl } from "../api.js";
 import { UserContext } from "../UserContext.jsx";
-import { API_BASE_URL } from "../config.js";
 
 function UserMenu() {
   const [open, setOpen] = useState(false);
@@ -34,6 +33,8 @@ function UserMenu() {
       console.error("Logout failed", e);
     } finally {
       localStorage.removeItem("isLoggedIn");
+      localStorage.removeItem("userName");
+      localStorage.removeItem("userImage");
       setIsLoggedIn(false);
       setProfile(null);
       navigate("/");
@@ -43,21 +44,9 @@ function UserMenu() {
   if (!isLoggedIn) {
     return (
       <button
-        onClick={() => {
-          window.location.href = `${API_BASE_URL}/login`;
-        }}
-        className="px-4 py-2 bg-green-500 text-black rounded-full"
-      >
-        Giriş Yap
-      </button>
-    );
-  }
-
-  if (!isLoggedIn) {
-    return (
-      <button
-        onClick={() => {
-          window.location.href = `${API_BASE_URL}/login`;
+        onClick={async () => {
+          const url = await fetchAuthUrl();
+          window.location.href = url;
         }}
         className="px-4 py-2 bg-green-500 text-black rounded-full"
       >


### PR DESCRIPTION
## Summary
- clean up logout to clear current user state
- use API call to start login from header menu
- update user menu login logic and clear cached profile info on logout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pip install -r Backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684fecf553a483218dc96f6e6a660727